### PR TITLE
Add support for other currencies in test meta box

### DIFF
--- a/src/Admin/AdminModule.php
+++ b/src/Admin/AdminModule.php
@@ -635,13 +635,21 @@ class AdminModule {
 		}
 
 		// Amount.
-		$string = \filter_input( INPUT_POST, 'test_amount', \FILTER_SANITIZE_STRING );
+		$currency_code = 'EUR';
+
+		if ( \array_key_exists( 'test_currency_code', $_POST ) ) {
+			$currency_code = \sanitize_text_field( \wp_unslash( $_POST['test_currency_code'] ) );
+		}
+
+		$value = \filter_input( INPUT_POST, 'test_amount', \FILTER_SANITIZE_STRING );
 
 		try {
-			$amount = Number::from_string( $string );
+			$amount = Number::from_string( $value );
 		} catch ( \Exception $e ) {
 			\wp_die( \esc_html( $e->getMessage() ) );
 		}
+
+		$price = new Money( $amount, $currency_code );
 
 		/*
 		 * Payment.
@@ -727,8 +735,6 @@ class AdminModule {
 		$payment->lines = new PaymentLines();
 
 		$line = $payment->lines->new_line();
-
-		$price = new Money( $amount, 'EUR' );
 
 		$line->set_name( __( 'Test', 'pronamic_ideal' ) );
 		$line->set_unit_price( $price );

--- a/views/meta-box-gateway-test.php
+++ b/views/meta-box-gateway-test.php
@@ -10,6 +10,7 @@
  */
 
 use Pronamic\WordPress\Money\Currency;
+use Pronamic\WordPress\Money\Currencies;
 use Pronamic\WordPress\Pay\Core\PaymentMethods;
 use Pronamic\WordPress\Pay\Plugin;
 
@@ -67,7 +68,7 @@ try {
 	<?php
 }
 
-$currency = Currency::get_instance( 'EUR' );
+$currency_default = Currency::get_instance( 'EUR' );
 
 ?>
 <table class="form-table">
@@ -118,7 +119,28 @@ $currency = Currency::get_instance( 'EUR' );
 			<?php esc_html_e( 'Amount', 'pronamic_ideal' ); ?>
 		</th>
 		<td>
-			<label for="test_amount"><?php echo \esc_html( (string) $currency->get_symbol() ); ?></label>
+			<select name="test_currency_code">
+				<?php
+
+				foreach ( Currencies::get_currencies() as $currency ) {
+					$label = $currency->get_alphabetic_code();
+
+					$symbol = $currency->get_symbol();
+
+					if ( null !== $symbol ) {
+						$label = sprintf( '%s (%s)', $label, $symbol );
+					}
+
+					printf(
+						'<option value="%s" %s>%s</option>',
+						esc_attr( $currency->get_alphabetic_code() ),
+						selected( $currency->get_alphabetic_code(), $currency_default->get_alphabetic_code(), false ),
+						esc_html( $label )
+					);
+				}
+
+				?>
+			</select>
 
 			<input name="test_amount" id="test_amount" class="regular-text code pronamic-pay-form-control" value="" type="number" step="any" size="6" autocomplete="off" />
 		</td>


### PR DESCRIPTION
**Before**

<img width="638" alt="Schermafbeelding 2022-05-17 om 15 32 33" src="https://user-images.githubusercontent.com/869674/168829473-a17b8424-efe8-4eb9-9059-c9c99dcf4e64.png">

**After**

<img width="761" alt="Schermafbeelding 2022-05-17 om 16 02 04" src="https://user-images.githubusercontent.com/869674/168829525-50c84366-f0d9-4be6-840f-aaf4a9aa71bb.png">

Useful for, for example, testing the payment method Swish via Adyen:

> **Swish**
> Country Code: `SE`
> Currency: `SEK`

https://github.com/pronamic/wp-pronamic-pay-adyen/issues/9#issuecomment-1128829915
