### PR TITLE
41 regarding cancel subscription function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 This projects adheres to [Semantic Versioning](http://semver.org/) and [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased][unreleased]
--
+- Removed `Gateway->update_subscription( Payment $payment )` method, no longer used. ([#pronamic/wp-pay-core#41](https://github.com/pronamic/wp-pay-core/issues/41))
 
 ## [4.4.0] - 2022-09-26
 - Fixed list table styling on mobile (pronamic/wp-pay-core#72).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable changes to this project will be documented in this file.
 This projects adheres to [Semantic Versioning](http://semver.org/) and [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased][unreleased]
-- Removed `Gateway->update_subscription( Payment $payment )` method, no longer used. ([#pronamic/wp-pay-core#41](https://github.com/pronamic/wp-pay-core/issues/41))
-- Removed `Gateway->cancel_subscription( Subscription $subscription )` method, no longer used. ([#pronamic/wp-pay-core#41](https://github.com/pronamic/wp-pay-core/issues/41)).
+- Removed `Gateway->update_subscription( Payment $payment )` method, no longer used. ([pronamic/wp-pay-core#41](https://github.com/pronamic/wp-pay-core/issues/41))
+- Removed `Gateway->cancel_subscription( Subscription $subscription )` method, no longer used. ([pronamic/wp-pay-core#41](https://github.com/pronamic/wp-pay-core/issues/41)).
 
 ## [4.4.0] - 2022-09-26
 - Fixed list table styling on mobile (pronamic/wp-pay-core#72).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This projects adheres to [Semantic Versioning](http://semver.org/) and [Keep a C
 
 ## [Unreleased][unreleased]
 - Removed `Gateway->update_subscription( Payment $payment )` method, no longer used. ([#pronamic/wp-pay-core#41](https://github.com/pronamic/wp-pay-core/issues/41))
+- Removed `Gateway->cancel_subscription( Subscription $subscription )` method, no longer used. ([#pronamic/wp-pay-core#41](https://github.com/pronamic/wp-pay-core/issues/41)).
 
 ## [4.4.0] - 2022-09-26
 - Fixed list table styling on mobile (pronamic/wp-pay-core#72).

--- a/src/Core/Gateway.php
+++ b/src/Core/Gateway.php
@@ -242,16 +242,6 @@ abstract class Gateway {
 	}
 
 	/**
-	 * Handle subscription cancellation.
-	 *
-	 * @param Subscription $subscription The subscription to handle cancellation for.
-	 * @return void
-	 */
-	public function cancel_subscription( Subscription $subscription ) {
-
-	}
-
-	/**
 	 * Redirect to the gateway action URL.
 	 *
 	 * @param Payment $payment The payment to redirect for.

--- a/src/Core/Gateway.php
+++ b/src/Core/Gateway.php
@@ -242,16 +242,6 @@ abstract class Gateway {
 	}
 
 	/**
-	 * Handle subscription update.
-	 *
-	 * @param Payment $payment The payment to handle subscription update for.
-	 * @return void
-	 */
-	public function update_subscription( Payment $payment ) {
-
-	}
-
-	/**
 	 * Handle subscription cancellation.
 	 *
 	 * @param Subscription $subscription The subscription to handle cancellation for.


### PR DESCRIPTION
- Removed `Gateway->update_subscription( Payment $payment )` method, no longer used. ([#pronamic/wp-pay-core#41](https://github.com/pronamic/wp-pay-core/issues/41))
- Removed `Gateway->cancel_subscription( Subscription $subscription )` method, no longer used. ([#pronamic/wp-pay-core#41](https://github.com/pronamic/wp-pay-core/issues/41)).
