### PR TITLE
Add support for multi-dimensional array in `Util::html_hidden_fields()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 This projects adheres to [Semantic Versioning](http://semver.org/) and [Keep a CHANGELOG](http://keepachangelog.com/).
 
 ## [Unreleased][unreleased]
--
+- Added support for multi-dimensional array in `Util::html_hidden_fields( $data )` method. ([#pronamic/wp-pay-core#73](https://github.com/pronamic/wp-pay-core/issues/73))
 
 ## [4.4.0] - 2022-09-26
 - Fixed list table styling on mobile (pronamic/wp-pay-core#72).

--- a/src/Util.php
+++ b/src/Util.php
@@ -202,7 +202,7 @@ class Util {
 	 * Flattens a multi-dimensional array into a single level array that uses "square bracket" notation to indicate depth.
 	 * 
 	 * @link https://github.com/pronamic/wp-pay-core/issues/73
-	 * @param iterable $data   Data,
+	 * @param iterable $data   Data.
 	 * @param string   $parent Parent.
 	 * @param array    $result Result.
 	 * @return array

--- a/src/Util.php
+++ b/src/Util.php
@@ -199,6 +199,30 @@ class Util {
 	}
 
 	/**
+	 * Flattens a multi-dimensional array into a single level array that uses "square bracket" notation to indicate depth.
+	 * 
+	 * @link https://github.com/pronamic/wp-pay-core/issues/73
+	 * @param iterable $data   Data,
+	 * @param string   $parent Parent.
+	 * @param array    $result Result.
+	 * @return array
+	 */
+	private static function array_square_bracket( $data, $parent = '', $result = [] ) {
+		foreach ( $data as $key => $item ) {
+			if ( '' !== $parent ) {
+				$key = $parent . '[' . $key . ']';
+			}
+
+			if ( is_array( $item ) ) {
+				$result = self::array_square_bracket( $item, $key, $result );
+			} else {
+				$result[ $key ] = $item;
+			}
+		}
+		
+		return $result;
+	}
+	/**
 	 * Get hidden inputs HTML for data.
 	 *
 	 * @param array $data Array with name and value pairs to convert to hidden HTML input elements.
@@ -207,6 +231,8 @@ class Util {
 	 */
 	public static function html_hidden_fields( $data ) {
 		$html = '';
+
+		$data = self::array_square_bracket( $data );
 
 		foreach ( $data as $name => $value ) {
 			$html .= sprintf( '<input type="hidden" name="%s" value="%s" />', esc_attr( $name ), esc_attr( $value ) );


### PR DESCRIPTION
- Added support for multi-dimensional array in `Util::html_hidden_fields( $data )` method. ([#pronamic/wp-pay-core#73](https://github.com/pronamic/wp-pay-core/issues/73))
