### PR TITLE
Allow subscription payments at gateways without recurring support

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1192,10 +1192,6 @@ class Plugin {
 
 		// Start payment at the gateway.
 		try {
-			if ( \count( $subscriptions ) > 0 && ! $gateway->supports( 'recurring' ) ) {
-				throw new \Exception( 'Gateway does not support recurring payments.' );
-			}
-
 			self::pronamic_service( $payment );
 
 			$gateway->start( $payment );


### PR DESCRIPTION
Related issue:

- https://github.com/pronamic/wp-pronamic-pay-woocommerce/issues/15