### PR TITLE
Trim whitespace while saving values.

### DIFF
--- a/src/Admin/AdminGatewayPostType.php
+++ b/src/Admin/AdminGatewayPostType.php
@@ -418,6 +418,8 @@ class AdminGatewayPostType {
 				$value = \filter_input( INPUT_POST, $name, $filter, $options );
 			}
 
+	        $value = \trim( $value );
+
 			// Update post meta.
 			if ( '' !== $value ) {
 				\update_post_meta( $post_id, $name, $value );


### PR DESCRIPTION
Sometimes users add spaces/tabs while copying keys. It will help to fix this issue.