### PR TITLE
Don't show upgrade notice on fresh installs.

### DIFF
--- a/src/AbstractIntegration.php
+++ b/src/AbstractIntegration.php
@@ -239,7 +239,7 @@ abstract class AbstractIntegration {
 			return null;
 		}
 
-		return \get_option( $this->version_option_name );
+		return \get_option( $this->version_option_name, null );
 	}
 
 	/**
@@ -289,7 +289,7 @@ abstract class AbstractIntegration {
 			return null;
 		}
 
-		return \get_option( $this->db_version_option_name );
+		return \get_option( $this->db_version_option_name, null );
 	}
 
 	/**
@@ -299,5 +299,32 @@ abstract class AbstractIntegration {
 	 */
 	public function get_upgrades() {
 		return $this->upgrades;
+	}
+
+	/**
+	 * Maybe install.
+	 *
+	 * @return void
+	 */
+	public function maybe_install() {
+		if ( null === $this->version_option_name ) {
+			return;
+		}
+
+		if ( null === $this->version ) {
+			return;
+		}
+
+		if ( \get_option( $this->version_option_name, null ) === $this->version ) {
+			return;
+		}
+
+		\update_option( $this->version_option_name, $this->version );
+
+		$db_version = \get_option( $this->db_version_option_name, null );
+
+		if ( null === $db_version ) {
+			\update_option( $this->db_version_option_name, $this->version );
+		}
 	}
 }

--- a/src/Admin/Install.php
+++ b/src/Admin/Install.php
@@ -76,9 +76,7 @@ class Install {
 	 */
 	public function admin_init() {
 		// Install.
-		if ( get_option( 'pronamic_pay_version' ) !== $this->plugin->get_version() ) {
-			$this->install();
-		}
+		$this->maybe_install();
 
 		// Notices.
 		add_action( 'admin_notices', [ $this, 'admin_notice_upgrades_available' ], 20 );
@@ -134,6 +132,20 @@ class Install {
 		$args[] = 'pronamic_pay_upgraded';
 
 		return $args;
+	}
+
+	/**
+	 * Maybe install.
+	 */
+	private function maybe_install() {
+		if ( \get_option( 'pronamic_pay_version', null ) !== $this->plugin->get_version() ) {
+			$this->install();
+		}
+
+		// Integrations.
+		foreach ( $this->plugin->integrations as $integration ) {
+			$integration->maybe_install();
+		}
 	}
 
 	/**
@@ -310,13 +322,17 @@ class Install {
 	 * @return bool True if database update is required, false otherwise.
 	 */
 	public function requires_upgrade() {
-		$current_db_version = get_option( 'pronamic_pay_db_version' );
+		$current_db_version = \get_option( 'pronamic_pay_db_version', null );
 
 		if (
-			// Check for old database version notation without dots, for example `366`.
-			false === strpos( $current_db_version, '.' )
-				||
-			version_compare( $current_db_version, max( $this->db_updates ), '<' )
+			null !== $current_db_version
+				&&
+			(
+				// Check for old database version notation without dots, for example `366`.
+				false === \strpos( $current_db_version, '.' )
+					||
+				\version_compare( $current_db_version, \max( $this->db_updates ), '<' )
+			)
 		) {
 			return true;
 		}


### PR DESCRIPTION
Ideally, all extensions should pass all of the following arguments:

```php
'version_option_name'    => 'pronamic_pay_mollie_version',
'db_version_option_name' => 'pronamic_pay_mollie_db_version',
```

Each integration should already have a version number stored in the database after a clean install. That is the only way to determine whether or not an upgrade message should be shown.
