### PR TITLE
Don't set payment method on manual subscription renewal.

### DIFF
--- a/src/Subscriptions/SubscriptionsModule.php
+++ b/src/Subscriptions/SubscriptionsModule.php
@@ -358,6 +358,8 @@ class SubscriptionsModule {
 
 				$payment->order_id = $subscription->get_order_id();
 
+				$payment->set_payment_method( null );
+
 				$payment->set_lines( $subscription->get_lines() );
 				$payment->set_total_amount( $current_phase->get_amount() );
 

--- a/src/Subscriptions/SubscriptionsModule.php
+++ b/src/Subscriptions/SubscriptionsModule.php
@@ -358,6 +358,13 @@ class SubscriptionsModule {
 
 				$payment->order_id = $subscription->get_order_id();
 
+				/**
+				 * We set the payment method to `null` so that users get the 
+				 * chance to choose a payment method themselves if possible.
+				 * 
+				 * @link https://github.com/pronamic/wp-pronamic-pay-mollie/issues/23
+				 * @link https://github.com/pronamic/wp-pay-core/pull/99
+				 */
 				$payment->set_payment_method( null );
 
 				$payment->set_lines( $subscription->get_lines() );


### PR DESCRIPTION
Fix https://github.com/pronamic/wp-pronamic-pay-mollie/issues/23.