### PR TITLE
No longer execute the `$gateway->start( $payment )` method in the red…

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -604,8 +604,6 @@ class Plugin {
 
 			// Handle HTML form redirect.
 			if ( $gateway->is_html_form() ) {
-				$gateway->start( $payment );
-
 				$gateway->redirect( $payment );
 			}
 		}


### PR DESCRIPTION
No longer execute the `$gateway->start( $payment )` method in the redirect routine for HTML form gateways.

- https://github.com/pronamic/wp-pay-core/issues/97
