### PR TITLE
Show button to create payment status pages when at least one page is not set or does not exist anymore

### DIFF
--- a/src/Admin/AdminModule.php
+++ b/src/Admin/AdminModule.php
@@ -348,6 +348,15 @@ class AdminModule {
 	 */
 	private function create_pages( $pages, $parent = null ) {
 		foreach ( $pages as $page ) {
+			// Check if page already exists.
+			if ( isset( $page['option_name'] ) ) {
+				$page_id = \get_option( $page['option_name'] );
+
+				if ( ! empty( $page_id ) && null !== \get_post( $page_id ) ) {
+					continue;
+				}
+			}
+
 			$post = [
 				'post_title'     => $page['post_title'],
 				'post_name'      => $page['post_title'],

--- a/src/Admin/AdminModule.php
+++ b/src/Admin/AdminModule.php
@@ -341,20 +341,17 @@ class AdminModule {
 	/**
 	 * Create pages.
 	 *
-	 * @param array    $pages   Page.
-	 * @param int|null $parent Parent post ID.
+	 * @param array $pages Pages.
 	 * @return void
 	 * @throws \Exception When creating page fails.
 	 */
-	private function create_pages( $pages, $parent = null ) {
+	private function create_pages( $pages ) {
 		foreach ( $pages as $page ) {
 			// Check if page already exists.
-			if ( isset( $page['option_name'] ) ) {
-				$page_id = \get_option( $page['option_name'] );
+			$page_id = \get_option( $page['option_name'] );
 
-				if ( ! empty( $page_id ) && null !== \get_post( $page_id ) ) {
-					continue;
-				}
+			if ( false !== \get_post_status( $page_id ) ) {
+				continue;
 			}
 
 			$post = [
@@ -382,13 +379,7 @@ class AdminModule {
 				}
 			}
 
-			if ( isset( $page['option_name'] ) ) {
-				update_option( $page['option_name'], $result );
-			}
-
-			if ( isset( $page['children'] ) ) {
-				$this->create_pages( $page['children'], $result );
-			}
+			update_option( $page['option_name'], $result );
 		}
 	}
 
@@ -408,78 +399,68 @@ class AdminModule {
 
 		$pages = [
 			[
-				'post_title'   => __( 'Payment Status', 'pronamic_ideal' ),
-				'post_name'    => __( 'payment', 'pronamic_ideal' ),
-				'post_content' => '',
+				'post_title'   => __( 'Payment completed', 'pronamic_ideal' ),
+				'post_name'    => __( 'payment-completed', 'pronamic_ideal' ),
+				'post_content' => sprintf(
+					'<p>%s</p>',
+					__( 'The payment has been successfully completed.', 'pronamic_ideal' )
+				),
 				'post_meta'    => [
 					'_yoast_wpseo_meta-robots-noindex' => true,
 				],
-				'children'     => [
-					'completed' => [
-						'post_title'   => __( 'Payment completed', 'pronamic_ideal' ),
-						'post_name'    => __( 'completed', 'pronamic_ideal' ),
-						'post_content' => sprintf(
-							'<p>%s</p>',
-							__( 'The payment has been successfully completed.', 'pronamic_ideal' )
-						),
-						'post_meta'    => [
-							'_yoast_wpseo_meta-robots-noindex' => true,
-						],
-						'option_name'  => 'pronamic_pay_completed_page_id',
-					],
-					'cancel'    => [
-						'post_title'   => __( 'Payment cancelled', 'pronamic_ideal' ),
-						'post_name'    => __( 'cancelled', 'pronamic_ideal' ),
-						'post_content' => sprintf(
-							'<p>%s</p>',
-							__( 'You have cancelled the payment.', 'pronamic_ideal' )
-						),
-						'post_meta'    => [
-							'_yoast_wpseo_meta-robots-noindex' => true,
-						],
-						'option_name'  => 'pronamic_pay_cancel_page_id',
-					],
-					'expired'   => [
-						'post_title'   => __( 'Payment expired', 'pronamic_ideal' ),
-						'post_name'    => __( 'expired', 'pronamic_ideal' ),
-						'post_content' => sprintf(
-							'<p>%s</p>',
-							__( 'Your payment session has expired.', 'pronamic_ideal' )
-						),
-						'post_meta'    => [
-							'_yoast_wpseo_meta-robots-noindex' => true,
-						],
-						'option_name'  => 'pronamic_pay_expired_page_id',
-					],
-					'error'     => [
-						'post_title'   => __( 'Payment error', 'pronamic_ideal' ),
-						'post_name'    => __( 'error', 'pronamic_ideal' ),
-						'post_content' => sprintf(
-							'<p>%s</p>',
-							__( 'An error has occurred during payment.', 'pronamic_ideal' )
-						),
-						'post_meta'    => [
-							'_yoast_wpseo_meta-robots-noindex' => true,
-						],
-						'option_name'  => 'pronamic_pay_error_page_id',
-					],
-					'unknown'   => [
-						'post_title'   => __( 'Payment status unknown', 'pronamic_ideal' ),
-						'post_name'    => __( 'unknown', 'pronamic_ideal' ),
-						'post_content' => sprintf(
-							'<p>%s</p>',
-							__( 'The payment status is unknown.', 'pronamic_ideal' )
-						),
-						'post_meta'    => [
-							'_yoast_wpseo_meta-robots-noindex' => true,
-						],
-						'option_name'  => 'pronamic_pay_unknown_page_id',
-					],
+				'option_name'  => 'pronamic_pay_completed_page_id',
+			],
+			[
+				'post_title'   => __( 'Payment cancelled', 'pronamic_ideal' ),
+				'post_name'    => __( 'payment-cancelled', 'pronamic_ideal' ),
+				'post_content' => sprintf(
+					'<p>%s</p>',
+					__( 'You have cancelled the payment.', 'pronamic_ideal' )
+				),
+				'post_meta'    => [
+					'_yoast_wpseo_meta-robots-noindex' => true,
 				],
+				'option_name'  => 'pronamic_pay_cancel_page_id',
+			],
+			[
+				'post_title'   => __( 'Payment expired', 'pronamic_ideal' ),
+				'post_name'    => __( 'payment-expired', 'pronamic_ideal' ),
+				'post_content' => sprintf(
+					'<p>%s</p>',
+					__( 'Your payment session has expired.', 'pronamic_ideal' )
+				),
+				'post_meta'    => [
+					'_yoast_wpseo_meta-robots-noindex' => true,
+				],
+				'option_name'  => 'pronamic_pay_expired_page_id',
+			],
+			[
+				'post_title'   => __( 'Payment error', 'pronamic_ideal' ),
+				'post_name'    => __( 'payment-error', 'pronamic_ideal' ),
+				'post_content' => sprintf(
+					'<p>%s</p>',
+					__( 'An error has occurred during payment.', 'pronamic_ideal' )
+				),
+				'post_meta'    => [
+					'_yoast_wpseo_meta-robots-noindex' => true,
+				],
+				'option_name'  => 'pronamic_pay_error_page_id',
+			],
+			[
+				'post_title'   => __( 'Payment status unknown', 'pronamic_ideal' ),
+				'post_name'    => __( 'payment-unknown', 'pronamic_ideal' ),
+				'post_content' => sprintf(
+					'<p>%s</p>',
+					__( 'The payment status is unknown.', 'pronamic_ideal' )
+				),
+				'post_meta'    => [
+					'_yoast_wpseo_meta-robots-noindex' => true,
+				],
+				'option_name'  => 'pronamic_pay_unknown_page_id',
 			],
 			[
 				'post_title'   => __( 'Subscription Canceled', 'pronamic_ideal' ),
-				'post_name'    => __( 'subscription', 'pronamic_ideal' ),
+				'post_name'    => __( 'subscription-canceled', 'pronamic_ideal' ),
 				'post_content' => sprintf(
 					'<p>%s</p>',
 					__( 'The subscription has been canceled.', 'pronamic_ideal' )

--- a/src/Admin/AdminSettings.php
+++ b/src/Admin/AdminSettings.php
@@ -202,19 +202,18 @@ class AdminSettings {
 
 				$pages = [ 'completed', 'cancel', 'expired', 'error', 'unknown' ];
 
-				$hide_button = true;
+				$statuses = \array_map(
+					function( $key ) {
+						$option_name = sprintf( 'pronamic_pay_%s_page_id', $key );
 
-				foreach ( $pages as $status ) {
-					$option_name = sprintf( 'pronamic_pay_%s_page_id', $status );
+						$page_id = \get_option( $option_name );
 
-					$option = get_option( $option_name );
+						return \get_post_status( $page_id );
+					},
+					$pages
+				);
 
-					if ( $hide_button && ( empty( $option ) || null === get_post( $option ) ) ) {
-						$hide_button = false;
-					}
-				}
-
-				if ( false === $hide_button ) {
+				if ( \in_array( false, $statuses, true ) ) {
 					submit_button(
 						__( 'Set default pages', 'pronamic_ideal' ),
 						'',

--- a/src/Admin/AdminSettings.php
+++ b/src/Admin/AdminSettings.php
@@ -202,17 +202,19 @@ class AdminSettings {
 
 				$pages = [ 'completed', 'cancel', 'expired', 'error', 'unknown' ];
 
+				$hide_button = true;
+
 				foreach ( $pages as $status ) {
 					$option_name = sprintf( 'pronamic_pay_%s_page_id', $status );
 
 					$option = get_option( $option_name );
 
-					if ( ! empty( $option ) ) {
-						$hide_button = true;
+					if ( $hide_button && ( empty( $option ) || null === get_post( $option ) ) ) {
+						$hide_button = false;
 					}
 				}
 
-				if ( ! isset( $hide_button ) ) {
+				if ( false === $hide_button ) {
 					submit_button(
 						__( 'Set default pages', 'pronamic_ideal' ),
 						'',


### PR DESCRIPTION
Fix #101.

One remaining 'issue': the parent page for the payment status pages — which does not have a stored page id option to check for — is also recreated if the action to create pages is performed a second time. Thoughts?