### PR TITLE
Remove `plugin_locale` filter for `nl_NL_formal` and `nl_BE`

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -308,9 +308,6 @@ class Plugin {
 		 */
 		add_action( 'plugins_loaded', [ $this, 'plugins_loaded' ], 0 );
 
-		// Plugin locale.
-		add_filter( 'plugin_locale', [ $this, 'plugin_locale' ], 10, 2 );
-
 		// Register styles.
 		add_action( 'init', [ $this, 'register_styles' ], 9 );
 
@@ -766,30 +763,6 @@ class Plugin {
 		\load_plugin_textdomain( 'pronamic_ideal', false, $rel_path . '/languages' );
 
 		\load_plugin_textdomain( 'pronamic-money', false, $rel_path . '/packages/pronamic/wp-money/languages' );
-	}
-
-	/**
-	 * Filter plugin locale.
-	 *
-	 * @param string $locale A WordPress locale identifier.
-	 * @param string $domain A WordPress text domain identifier.
-	 *
-	 * @return string
-	 */
-	public function plugin_locale( $locale, $domain ) {
-		if ( 'pronamic_ideal' !== $domain ) {
-			return $locale;
-		}
-
-		if ( 'nl_NL_formal' === $locale ) {
-			return 'nl_NL';
-		}
-
-		if ( 'nl_BE' === $locale ) {
-			return 'nl_NL';
-		}
-
-		return $locale;
 	}
 
 	/**


### PR DESCRIPTION
> If desired we could copy https://github.com/pronamic/wp-pronamic-pay/blob/main/languages/pronamic-ideal-nl_NL.po to:
> 
> * `pronamic-ideal-nl_NL_formal.php`
> * `pronamic-ideal-nl_BE.php`

@rvdsteege Should we do this? Or leave the translation of these locales to https://translate.wordpress.org/projects/wp-plugins/pronamic-ideal/?
