### PR TITLE
Changed priority of handle_returns and maybe_redirect to fix notification issue.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -269,8 +269,8 @@ class Plugin {
 		add_action( 'init', [ $this, 'register_styles' ], 9 );
 
 		// If WordPress is loaded check on returns and maybe redirect requests.
-		add_action( 'wp_loaded', [ $this, 'handle_returns' ], 10 );
-		add_action( 'wp_loaded', [ $this, 'maybe_redirect' ], 10 );
+		add_action( 'wp_loaded', [ $this, 'handle_returns' ], PHP_INT_MAX );
+		add_action( 'wp_loaded', [ $this, 'maybe_redirect' ], PHP_INT_MAX );
 
 		// Default date time format.
 		add_filter( 'pronamic_datetime_default_format', [ $this, 'datetime_format' ], 10, 1 );

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -269,8 +269,8 @@ class Plugin {
 		add_action( 'init', [ $this, 'register_styles' ], 9 );
 
 		// If WordPress is loaded check on returns and maybe redirect requests.
-		add_action( 'wp_loaded', [ $this, 'handle_returns' ], PHP_INT_MAX );
-		add_action( 'wp_loaded', [ $this, 'maybe_redirect' ], PHP_INT_MAX );
+		add_action( 'wp_loaded', [ $this, 'handle_returns' ], 100 );
+		add_action( 'wp_loaded', [ $this, 'maybe_redirect' ], 100 );
 
 		// Default date time format.
 		add_filter( 'pronamic_datetime_default_format', [ $this, 'datetime_format' ], 10, 1 );


### PR DESCRIPTION
Some plugins that perform tasks after payment confirmation (Eg WPNotif), get loaded late, because of which notification does not get triggered after payment confirmation if we confirm the payment sooner than they get loaded. So, I have increased the priority of handle_returns and maybe_redirect to max possible value, to make sure, notification plugins or any other dependent plugin gets loaded before payment gets confirmed.
My client reported this issue in which SMS and Whatsapp message was not getting triggered by WPNotif in case of Knit Pay whereas WPNotif was working fine for other payment gateway plugins.