### PR TITLE
Do not update subscription status for payment status updates of WooCommerce payment method changes

### DIFF
--- a/src/Subscriptions/SubscriptionsModule.php
+++ b/src/Subscriptions/SubscriptionsModule.php
@@ -139,7 +139,11 @@ class SubscriptionsModule {
 	 */
 	public function payment_status_update( $payment ) {
 		// Payment method changes do not affect the subscription status.
-		if ( 'subscription_payment_method_change' === $payment->get_source() ) {
+		if (
+			'subscription_payment_method_change' === $payment->get_source()
+				||
+			true === $payment->get_meta( 'woocommerce_subscription_change_payment_method' )
+		) {
 			return;
 		}
 


### PR DESCRIPTION
Together with PR in https://github.com/pronamic/wp-pronamic-pay-woocommerce, this fixes https://github.com/pronamic/pronamic.shop/issues/56.