### PR TITLE
Only filter out `null` values when getting payment line JSON.

### DIFF
--- a/src/Payments/PaymentLine.php
+++ b/src/Payments/PaymentLine.php
@@ -530,6 +530,10 @@ class PaymentLine implements \Stringable {
 		$properties = \array_filter(
 			$properties,
 			function ( $value ) {
+				if ( \is_array( $value ) ) {
+					return 0 !== \count( $value );
+				}
+
 				return null !== $value;
 			}
 		);


### PR DESCRIPTION
Fix #226.