### PR TITLE
EUR currency was getting saved in all refunds for non EUR currencies.

### DIFF
--- a/src/Payments/Payment.php
+++ b/src/Payments/Payment.php
@@ -265,10 +265,6 @@ class Payment extends PaymentInfo {
 	 * @return Money
 	 */
 	public function get_refunded_amount() {
-		if ( $this->refunded_amount->get_currency() !== $this->get_total_amount()->get_currency() ) {
-			$this->refunded_amount->set_currency( $this->get_total_amount()->get_currency() );
-		}
-
 		return $this->refunded_amount;
 	}
 

--- a/src/Payments/Payment.php
+++ b/src/Payments/Payment.php
@@ -265,6 +265,10 @@ class Payment extends PaymentInfo {
 	 * @return Money
 	 */
 	public function get_refunded_amount() {
+		if ( $this->refunded_amount->get_currency() !== $this->get_total_amount()->get_currency() ) {
+			$this->refunded_amount->set_currency( $this->get_total_amount()->get_currency() );
+		}
+
 		return $this->refunded_amount;
 	}
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1147,6 +1147,9 @@ class Plugin {
 			$payment->refunds[] = $refund;
 
 			$refunded_amount = $payment->get_refunded_amount();
+			if ( $refunded_amount->is_zero() && $refunded_amount->get_currency() !== $refund->get_amount()->get_currency() ){
+				$refunded_amount->set_currency( $refund->get_amount()->get_currency() );
+			}
 
 			$refunded_amount = $refunded_amount->add( $refund->get_amount() );
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1147,7 +1147,7 @@ class Plugin {
 			$payment->refunds[] = $refund;
 
 			$refunded_amount = $payment->get_refunded_amount();
-			if ( $refunded_amount->is_zero() && $refunded_amount->get_currency() !== $refund->get_amount()->get_currency() ){
+			if ( $refunded_amount->is_zero() && $refunded_amount->get_currency() !== $refund->get_amount()->get_currency() ) {
 				$refunded_amount->set_currency( $refund->get_amount()->get_currency() );
 			}
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1148,6 +1148,9 @@ class Plugin {
 
 			$refunded_amount = $payment->get_refunded_amount();
 
+			// Prevent the default Money currency (EUR) from leaking into the refunded amount for non-EUR payments.
+			$refunded_amount->set_currency( $payment->get_total_amount()->get_currency() );
+
 			$refunded_amount = $refunded_amount->add( $refund->get_amount() );
 
 			$payment->set_refunded_amount( $refunded_amount );

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1148,9 +1148,6 @@ class Plugin {
 
 			$refunded_amount = $payment->get_refunded_amount();
 
-			// Prevent the default Money currency (EUR) from leaking into the refunded amount for non-EUR payments.
-			$refunded_amount->set_currency( $payment->get_total_amount()->get_currency() );
-
 			$refunded_amount = $refunded_amount->add( $refund->get_amount() );
 
 			$payment->set_refunded_amount( $refunded_amount );

--- a/views/meta-box-payment-lines.php
+++ b/views/meta-box-payment-lines.php
@@ -203,12 +203,20 @@ if ( empty( $lines ) ) : ?>
 
 										$line_total = $refund_line->get_total_amount();
 
+										if ( $refunded_amount->is_zero() && $refunded_amount->get_currency() !== $line_total->get_currency() ) {
+											$refunded_amount->set_currency( $line_total->get_currency() );
+										}
+
 										$refunded_amount = $refunded_amount->add( $line_total );
 
 										if ( $line_total instanceof TaxedMoney ) {
 											$tax_amount = $line_total->get_tax_amount();
 
 											if ( null !== $tax_amount ) {
+												if ( $refunded_tax->is_zero() && $refunded_tax->get_currency() !== $tax_amount->get_currency() ) {
+													$refunded_tax->set_currency( $tax_amount->get_currency() );
+												}
+
 												$refunded_tax = $refunded_tax->add( $tax_amount );
 											}
 										}


### PR DESCRIPTION
Prevent the default Money currency (EUR) from leaking into the refunded amount for non-EUR payments.