### PR TITLE
Allow woocommerce/action-scheduler ^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,7 @@
 		"pronamic/wp-number": "^1.3",
 		"pronamic/wp-pay-logos": "^2.3",
 		"viison/address-splitter": "^0.3.4",
-		"woocommerce/action-scheduler": "^3.9"
+		"woocommerce/action-scheduler": "^3.9 || ^4.0"
 	},
 	"require-dev": {
 		"overtrue/phplint": "^9.6",

--- a/pronamic-pay-core.php
+++ b/pronamic-pay-core.php
@@ -5,7 +5,7 @@
  * Description: Core components for the WordPress payment processing library.
  *
  * Version: 4.33.0
- * Requires at least: 6.6
+ * Requires at least: 6.8
  * Requires PHP: 8.0
  *
  * Author: Pronamic


### PR DESCRIPTION
Update the `woocommerce/action-scheduler` Composer constraint to also allow the new 4.0 branch using an OR operator.